### PR TITLE
Update 0.1.1 - Memory Fixes

### DIFF
--- a/Assets/Lukas/FP_CineBrain Blends.asset
+++ b/Assets/Lukas/FP_CineBrain Blends.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   - m_From: '**ANY CAMERA**'
     m_To: MinigameCamera
     m_Blend:
-      m_Style: 6
+      m_Style: 0
       m_Time: 1
       m_CustomCurve:
         serializedVersion: 2

--- a/Assets/Lukas/Scripts/MinigameSystem/Memory/MemoryGame.cs
+++ b/Assets/Lukas/Scripts/MinigameSystem/Memory/MemoryGame.cs
@@ -107,13 +107,13 @@ namespace Scripts.MinigameSystem.Memory
             Cursor.visible = false;
             playerInput.enabled = true;
             playerInput.currentActionMap.Enable();
-            isGameOver = true;
             iconDetector.ChangeIconDisplayStatus(EIconDisplayState.DISPLAY);
             yield return StartCoroutine(blackoutTransition.TransitionFromBlackout(fakeVolumeImage));
         }
 
         protected override void EndGame()
         {
+            isGameOver = true;
             base.EndGame();
             StartCoroutine(EndGameRoutine());
             
@@ -144,7 +144,7 @@ namespace Scripts.MinigameSystem.Memory
             else
             {
                 StartCoroutine(TurnAroundRoutine(_card, true));
-                yield return TurnAroundRoutine(firstSelectedCard, true);
+                yield return TurnAroundRoutine(firstSelectedCard, true, true);
             }
 
             waitRoutine = null;
@@ -158,7 +158,7 @@ namespace Scripts.MinigameSystem.Memory
             return new Vector3(removedPosition.x, removedPosition.y + removedCards * 0.015f, removedPosition.z);
         }
 
-        IEnumerator TurnAroundRoutine(MemoryCard _card, bool _reverse)
+        IEnumerator TurnAroundRoutine(MemoryCard _card, bool _reverse, bool _secondCard = false)
         {
             if (turnRoutine != null) yield break;
             var startRot = _card.transform.rotation;
@@ -174,7 +174,7 @@ namespace Scripts.MinigameSystem.Memory
 
             yield return OverTimeMovement.MoveOverTime(startPos, liftedPos, liftDuration, _pos => _card.transform.localPosition = _pos);
 
-            turnEventEmitter.Play();
+            if(!_secondCard)turnEventEmitter.Play();
             yield return OverTimeMovement.MoveOverTime(startRot, endRot, flipDuration, _rot => _card.transform.rotation = _rot);
 
             yield return OverTimeMovement.MoveOverTime(liftedPos, startPos, liftDuration, _pos => _card.transform.localPosition = _pos);

--- a/Assets/Lukas/Scripts/Movement/PlayerController.cs
+++ b/Assets/Lukas/Scripts/Movement/PlayerController.cs
@@ -249,6 +249,7 @@ namespace Scripts.Movement
         {
             if (_callbackContext.phase != InputActionPhase.Started) return;
             Physics.Raycast(mainUnityCamera.ScreenPointToRay(Input.mousePosition), out var hit, Mathf.Infinity, memoryCardLayer);
+            if(hit.collider == null) return;
             var card = hit.collider.gameObject.GetComponentInParent<MemoryCard>();
             if (card == null) return;
             Debug.Log(hit.collider.gameObject.name);

--- a/Assets/Lukas/Scripts/UI/PauseMenu/PauseMenu.cs
+++ b/Assets/Lukas/Scripts/UI/PauseMenu/PauseMenu.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using FMOD.Studio;
 using Scripts.Movement;
 using Scripts.Scriptables.SceneLoader;
 using UnityEngine;
@@ -32,7 +33,8 @@ namespace Scripts.UI.PauseMenu
 
         public void ReturnToMainMenu()
         {
-            FMODUnity.RuntimeManager.PauseAllEvents(true);
+            var masterBus = FMODUnity.RuntimeManager.GetBus("bus:/");
+            masterBus.stopAllEvents(STOP_MODE.IMMEDIATE);
             FMODUnity.RuntimeManager.CoreSystem.update();
             FMODUnity.RuntimeManager.StudioSystem.update();
             mainMenuLoader.LoadScene();


### PR DESCRIPTION
**Fixes**
- Fixed Camera Transition towards memory minigame
- Fixed double sfx when turning back a wrong memory pair
- Fixed memory game not ending and perma looping sound
- Fixed memory game being playable from the start without finding the sketchbook first
- Fixed a null reference error when clicking the table that didnt do anything but was annoying during development